### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ When started go into File \> Execute Command
 
 
 Execute Command: `javaws C:\path\to\file.jnlp`
+
+
+## License
+
+This project is licensed under the Apache-2.0 license - see the [LICENSE](https://github.com/nokia/jspy/blob/master/licence.txt).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.